### PR TITLE
Prevent crash on wrong network

### DIFF
--- a/components/ReviewTransactionModal.tsx
+++ b/components/ReviewTransactionModal.tsx
@@ -46,7 +46,7 @@ const ReviewTransactionModal = ({
   const tokenDecimals = token?.decimals;
 
   const bigNumberAmount = parseUnits(tokenAmount! || '0', tokenDecimals);
-  const shieldFee = shieldingFees[chain?.id || 1];
+  const shieldFee = shieldingFees[chain?.id || 1] || shieldingFees[1];
   const feeAmount = parseUnits(tokenAmount! || '0', tokenDecimals)
     .mul(shieldFee)
     .div(10000);

--- a/components/TokenSelectionModal.tsx
+++ b/components/TokenSelectionModal.tsx
@@ -25,7 +25,7 @@ import { TokenListContextItem } from '@/contexts/TokenContext';
 import useNotifications from '@/hooks/useNotifications';
 import { ipfsDomain } from '@/utils/constants';
 import { parseIPFSUri } from '@/utils/ipfs';
-import { networks } from '@/utils/networks';
+import { getNetwork } from '@/utils/networks';
 
 type TokenSelectionModalProps = {
   isOpen: boolean;
@@ -123,7 +123,7 @@ const CustomTokenSelectionItem = ({
     onOpen: onBlacklistOpen,
     onClose: onBlacklistClose,
   } = useDisclosure();
-  const network = networks[chain?.id || 1];
+  const network = getNetwork(chain?.id);
   const tokenLink = `${network.blockExplorerUrl}token/${tokenAddress}`;
   const { data, isError, isLoading } = useWagmiToken({ address: tokenAddress });
   const { address } = useAccount();

--- a/components/TxForm.tsx
+++ b/components/TxForm.tsx
@@ -20,7 +20,7 @@ import useNotifications from '@/hooks/useNotifications';
 import useResolveUnstoppableDomainAddress from '@/hooks/useResolveUnstoppableDomainAddress';
 import useTokenAllowance from '@/hooks/useTokenAllowance';
 import { VALID_AMOUNT_REGEX, ethAddress } from '@/utils/constants';
-import { buildBaseToken, networks } from '@/utils/networks';
+import { buildBaseToken, getNetwork } from '@/utils/networks';
 
 type TxFormValues = {
   recipient: string;
@@ -31,7 +31,7 @@ type TxFormValues = {
 export const TxForm = ({ recipientAddress }: { recipientAddress?: string }) => {
   const { tokenAllowances, tokenList } = useToken();
   const { chain } = useNetwork();
-  const network = networks[chain?.id || 1];
+  const network = getNetwork(chain?.id);
   const { notifyUser } = useNotifications();
   const {
     handleSubmit,
@@ -81,7 +81,7 @@ export const TxForm = ({ recipientAddress }: { recipientAddress?: string }) => {
   const updateOnNetworkChange = useCallback(
     (net: GetNetworkResult) => {
       if (net && net?.chain) {
-        const chain = networks[net.chain.id];
+        const chain = getNetwork(net?.chain.id);
         const token = buildBaseToken(chain.baseToken, net.chain.id);
         setRecipient('');
         setRecipientDisplayName('');
@@ -97,6 +97,7 @@ export const TxForm = ({ recipientAddress }: { recipientAddress?: string }) => {
     const unwatch = watchNetwork(updateOnNetworkChange);
     return unwatch;
   }, [updateOnNetworkChange]);
+  console.log(chain);
 
   useEffect(() => {
     if (!selectedToken) {
@@ -186,6 +187,7 @@ export const TxForm = ({ recipientAddress }: { recipientAddress?: string }) => {
             size="lg"
             mt=".75rem"
             width="100%"
+            isDisabled={chain?.unsupported}
             onClick={async () => {
               if (!doErc20Approval) {
                 notifyUser({
@@ -202,11 +204,11 @@ export const TxForm = ({ recipientAddress }: { recipientAddress?: string }) => {
           </Button>
         ) : (
           <Button
+            isDisabled={chain?.unsupported || !unstoppableDomainResolutionIsLoading}
             type="submit"
             size="lg"
             mt=".75rem"
             width="100%"
-            disabled={!unstoppableDomainResolutionIsLoading}
           >
             Shield
           </Button>

--- a/components/TxForm.tsx
+++ b/components/TxForm.tsx
@@ -97,7 +97,6 @@ export const TxForm = ({ recipientAddress }: { recipientAddress?: string }) => {
     const unwatch = watchNetwork(updateOnNetworkChange);
     return unwatch;
   }, [updateOnNetworkChange]);
-  console.log(chain);
 
   useEffect(() => {
     if (!selectedToken) {

--- a/hooks/useRailgunProvider.tsx
+++ b/hooks/useRailgunProvider.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { setProviderForNetwork } from '@railgun-community/quickstart';
 import { BigNumber } from 'ethers';
 import { useNetwork, useProvider } from 'wagmi';
-import { networks } from '@/utils/networks';
+import { getNetwork, networks } from '@/utils/networks';
 import { loadProviders } from '@/utils/railgun';
 
 // Fee is in bips, e.g. a value of 25 is a 0.25% fee.
@@ -20,7 +20,7 @@ export const useRailgunProvider = () => {
   const [isProviderLoaded, setProviderLoaded] = useState<Boolean>(false);
   const [shieldingFees, setShieldingFees] = useState<ShieldFee>(fallbackShieldingFees);
   const { chain } = useNetwork();
-  const network = networks[chain?.id || 1];
+  const network = getNetwork(chain?.id);
   const provider = useProvider();
 
   useEffect(() => {

--- a/hooks/useRailgunTx.tsx
+++ b/hooks/useRailgunTx.tsx
@@ -12,7 +12,7 @@ import { useAccount, useSigner } from 'wagmi';
 import { useNetwork } from 'wagmi';
 import useShieldPrivateKey from '@/hooks/useShieldPrivateKey';
 import { ethAddress } from '@/utils/constants';
-import { networks } from '@/utils/networks';
+import { getNetwork } from '@/utils/networks';
 
 const useRailgunTx = () => {
   const { data: signer } = useSigner();
@@ -20,7 +20,7 @@ const useRailgunTx = () => {
   const { getShieldPrivateKey } = useShieldPrivateKey();
   const { chain } = useNetwork();
   const chainId = chain?.id || 1; // default to mainnet if no chain id
-  const { railgunNetworkName: network, wethAddress } = networks[chainId];
+  const { railgunNetworkName: network, wethAddress } = getNetwork(chainId);
   const [isShielding, setIsShielding] = useState(false);
 
   const shield = async (args: {

--- a/hooks/useTokenAllowance.tsx
+++ b/hooks/useTokenAllowance.tsx
@@ -3,12 +3,12 @@ import { readContract } from '@wagmi/core';
 import useSWR from 'swr';
 import { erc20ABI, useAccount, useNetwork } from 'wagmi';
 import { ethAddress } from '@/utils/constants';
-import { networks } from '@/utils/networks';
+import { getNetwork } from '@/utils/networks';
 
 const useTokenAllowance = (props: { address: string }) => {
   const { chain } = useNetwork();
   const { address } = useAccount();
-  const network = networks[chain?.id || 1];
+  const network = getNetwork(chain?.id);
 
   const chainId = network.chainId;
   const { isLoading, error, data } = useSWR(

--- a/hooks/useTokenAllowances.tsx
+++ b/hooks/useTokenAllowances.tsx
@@ -4,12 +4,12 @@ import useSWR from 'swr';
 import { erc20ABI, useAccount, useNetwork } from 'wagmi';
 import { TokenListItem } from '@/hooks/useTokenList';
 import { ethAddress } from '@/utils/constants';
-import { networks } from '@/utils/networks';
+import { getNetwork } from '@/utils/networks';
 
 const useTokenAllowances = ({ tokenList }: { tokenList: TokenListItem[] }) => {
   const { chain } = useNetwork();
   const { address } = useAccount();
-  const network = networks[chain?.id || 1];
+  const network = getNetwork(chain?.id);
 
   const chainId = network.chainId;
   const { isLoading, error, data } = useSWR(

--- a/hooks/useTokenList.tsx
+++ b/hooks/useTokenList.tsx
@@ -1,6 +1,6 @@
 import { useNetwork } from 'wagmi';
 import tokenListJson from '@/public/tokenlist.json';
-import { buildBaseToken, networks } from '@/utils/networks';
+import { buildBaseToken, getNetwork } from '@/utils/networks';
 
 export interface TokenListItem {
   chainId: number;
@@ -14,7 +14,7 @@ export interface TokenListItem {
 export const useTokenList = () => {
   const { chain } = useNetwork();
   const chainId = chain?.id || 1; // default to mainnet if no chain id
-  const network = networks[chainId];
+  const network = getNetwork(chainId);
   const tokenList = tokenListJson.tokens.filter((token) => token.chainId === chainId);
   const baseToken = buildBaseToken(network.baseToken, chain?.id || 1);
   return { tokenList: [baseToken, ...tokenList] };

--- a/utils/networks.ts
+++ b/utils/networks.ts
@@ -137,7 +137,7 @@ export const getEtherscanUrl = (txHashOrAddress: string, chainId: number) => {
       ? 'address'
       : 'tx'
     : 'ens';
-  const chain = networks[chainId];
+  const chain = getNetwork(chainId);
   const networkPrefix = chain?.blockExplorerUrl ? chain?.blockExplorerUrl : 'https://etherscan.io';
   if (group === 'ens') {
     return `${networkPrefix}`;
@@ -156,4 +156,8 @@ export const buildBaseToken = (baseToken: BaseToken, chainId: number) => {
     logoURI: baseToken.logoURI,
     balance: BigNumber.from(0),
   };
+};
+
+export const getNetwork = (chainId: number | undefined) => {
+  return networks[chainId || 1] || networks[1];
 };

--- a/utils/railgun.ts
+++ b/utils/railgun.ts
@@ -6,7 +6,7 @@ import {
 } from '@railgun-community/quickstart';
 import { BrowserLevel } from 'browser-level';
 import localforage from 'localforage';
-import { networks } from './networks';
+import { getNetwork, networks } from './networks';
 
 export const loadProviders = async () => {
   // Whether to forward debug logs from Fallback Provider.
@@ -14,7 +14,7 @@ export const loadProviders = async () => {
   return Promise.all(
     Object.keys(networks).map(async (chainIdString) => {
       const chainId = Number(chainIdString);
-      const { railgunNetworkName, fallbackProviders } = networks[chainId];
+      const { railgunNetworkName, fallbackProviders } = getNetwork(chainId);
       return {
         chainId,
         providerInfo: await loadProvider(fallbackProviders, railgunNetworkName, shouldDebug),


### PR DESCRIPTION

#### Description

- I noticed the app was crashing on an unsupported network because of the networks object. I default us to ethereum to prevent errors and disabled the shield and approve button.


![Screenshot from 2023-02-01 23-30-54](https://user-images.githubusercontent.com/12705146/216232621-962630e8-0af7-4b81-b25a-98d35ee8bdd9.png)