### PR TITLE
Enable shielding button

### DIFF
--- a/components/TxForm.tsx
+++ b/components/TxForm.tsx
@@ -224,7 +224,7 @@ export const TxForm = ({ recipientAddress }: { recipientAddress?: string }) => {
           </Button>
         ) : (
           <Button
-            isDisabled={chain?.unsupported || !unstoppableDomainResolutionIsLoading}
+            isDisabled={chain?.unsupported || unstoppableDomainResolutionIsLoading}
             type="submit"
             size="lg"
             mt=".75rem"


### PR DESCRIPTION
#### Description
- Shielding button should only be disabled if unstoppable call is still loading or user is on an unsupported chain